### PR TITLE
Fix always invalid authorization

### DIFF
--- a/lib/Api.php
+++ b/lib/Api.php
@@ -57,7 +57,7 @@ class Api {
       "sign" => true
     ));
 
-    if ($result->authentication_key->role !== "ONLINE_SHOP" || $result->authentication_key->role !== "DEVICE") {
+    if ($result->authentication_key->role !== "ONLINE_SHOP" && $result->authentication_key->role !== "DEVICE") {
       throw new \Exception("Invalid authentication");
     }
 


### PR DESCRIPTION
Fix wrong check in `testAuthorization` as the role cannot be `ONLINE_SHOP` and `DEVICE` at the same time.