### PR TITLE
Make request working with newer curl versions

### DIFF
--- a/lib/Request.php
+++ b/lib/Request.php
@@ -252,6 +252,7 @@ class Request
 
         $curlOptions[CURLOPT_URL] = $options["url"];
         $curlOptions[CURLOPT_RETURNTRANSFER] = true;
+        $curlOptions[CURLOPT_HTTP_VERSION] = CURL_HTTP_VERSION_1_1;
 
         if ($options["method"] != "GET") {
             if ($options["method"] != "POST") {


### PR DESCRIPTION
I'm having some issues with a newer curl version (PHP 8.1 and CURL 7.81.0 on Linux)
It seems like it's using HTTP2 by default, so it doesn't work with your api anymore.
I haven't investigated further but by adding this line it works fine again.

Could you please get a bit deeper into the issue?
I actually couldn't investigate more.


> https://curl.se/libcurl/c/CURLOPT_HTTP_VERSION.html 
>
> Default
> Since curl 7.62.0: CURL_HTTP_VERSION_2TLS
> 
> Before that: CURL_HTTP_VERSION_1_1

Those are the curl info:
cURL support | enabled
-- | --
cURL Information | 7.81.0
Age | 9
Features
AsynchDNS | Yes
CharConv | No
Debug | No
GSS-Negotiate | No
IDN | Yes
IPv6 | Yes
krb4 | No
Largefile | Yes
libz | Yes
NTLM | Yes
NTLMWB | Yes
SPNEGO | Yes
SSL | Yes
SSPI | No
TLS-SRP | Yes
HTTP2 | Yes
GSSAPI | Yes
KERBEROS5 | Yes
UNIX_SOCKETS | Yes
PSL | Yes
HTTPS_PROXY | Yes
MULTI_SSL | No
BROTLI | Yes
Protocols | dict, file, ftp, ftps, gopher, gophers, http, https, imap, imaps, ldap, ldaps, mqtt, pop3, pop3s, rtmp, rtsp, scp, sftp, smb, smbs, smtp, smtps, telnet, tftp
Host | x86_64-pc-linux-gnu
SSL Version | OpenSSL/3.0.2
ZLib Version | 1.2.11
libSSH Version | libssh/0.9.6/openssl/zlib
